### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,47 +56,64 @@
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.6.0-dev.1730030720-ed78e4570",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0-dev.1730030720-ed78e4570.tgz",
-			"integrity": "sha512-Pt4vVi2N7jGawPY95/u8Rl123X2FBGvZkQGEYPUtXvvmEhMrrmAXjiAxLVg78PZh7ZCtC4mZ8ihyRpxhiA0i7A==",
+			"version": "1.0.0-dev.1732795526-2b0944a92",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-1.0.0-dev.1732795526-2b0944a92.tgz",
+			"integrity": "sha512-uYMEK/vmJebsABex0wPtfi0k5P4zgZyC7yCeHEbYHbt0bnksKy62yc+/9NLzd9egE6iZiRiS7a4ymUG4QHE7xw==",
 			"dependencies": {
-				"discord-api-types": "^0.37.103"
+				"discord-api-types": "^0.37.109"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.4.1-dev.1730030709-ed78e4570",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.1-dev.1730030709-ed78e4570.tgz",
-			"integrity": "sha512-pdktWn2YArBW4NSpdi3k+WThROGHl1FePlepnFQRhmDiZ3SuO8BoQySIDMBwcVdepFhhL6u5OReq9MrEDyP9RQ==",
+			"version": "3.0.0-dev.1732795513-2b0944a92",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-3.0.0-dev.1732795513-2b0944a92.tgz",
+			"integrity": "sha512-tq3CPZItvg4Mra4Iab0wC1/dffK+4BqxR/uOa2fcejWj/PIzjzvpXFtQqEjD8P0GB2Zhi6CC0Ixd8TNKussn2Q==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.1",
 				"@discordjs/util": "^1.1.1",
-				"@sapphire/async-queue": "^1.5.3",
-				"@sapphire/snowflake": "^3.5.3",
+				"@sapphire/async-queue": "^1.5.5",
+				"@sapphire/snowflake": "^3.5.5",
 				"@vladfrangu/async_event_emitter": "^2.4.6",
-				"discord-api-types": "^0.37.103",
+				"discord-api-types": "^0.37.109",
 				"magic-bytes.js": "^1.10.0",
-				"tslib": "^2.6.3",
-				"undici": "6.19.8"
+				"tslib": "^2.8.1",
+				"undici": "6.21.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
-		"node_modules/@discordjs/util": {
-			"version": "1.1.2-dev.1730030707-ed78e4570",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.2-dev.1730030707-ed78e4570.tgz",
-			"integrity": "sha512-oE04hQJ3gqSuc9mPwybqiqS5IQwC581QZNZjvQaFUk68349iND2RdVXIqTyr+hFoCPZ6zauGrVylWI/cBGmOYw==",
+		"node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+			"integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
 			"engines": {
-				"node": ">=18"
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/@discordjs/rest/node_modules/undici": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+			"integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
+		"node_modules/@discordjs/util": {
+			"version": "2.0.0-dev.1732795513-2b0944a92",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-2.0.0-dev.1732795513-2b0944a92.tgz",
+			"integrity": "sha512-Nc0XtAD2fnZkxrIe61SAxfDG2Nt0kvOqI8lbF5g8fjqJPU4c+T/9wlClHWORzPEUn0lZoQ8XAg5Oc8MgzZxRQQ==",
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/discordjs/discord.js?sponsor"
@@ -1250,9 +1267,9 @@
 			"dev": true
 		},
 		"node_modules/@sapphire/async-queue": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.3.tgz",
-			"integrity": "sha512-x7zadcfJGxFka1Q3f8gCts1F0xMwCKbZweM85xECGI0hBTeIZJGGCrHgLggihBoprlQ/hBmDR5LKfIPqnmHM3w==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+			"integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
@@ -1307,9 +1324,9 @@
 			}
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.12",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-			"integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+			"version": "8.5.13",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+			"integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -1377,9 +1394,9 @@
 			}
 		},
 		"node_modules/bson": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-6.9.0.tgz",
-			"integrity": "sha512-X9hJeyeM0//Fus+0pc5dSUMhhrrmWwQUtdavaQeF3Ta6m69matZkGWV/MrBcnwUeLC8W9kwwc2hfkZgUuCX3Ig==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-6.10.0.tgz",
+			"integrity": "sha512-ROchNosXMJD2cbQGm84KoP7vOGPO6/bOAW0veMMbzhXLqoZptcaYRVLitwvuhwhjjpU1qP4YZRWLhgETdgqUQw==",
 			"engines": {
 				"node": ">=16.20.1"
 			}
@@ -1431,9 +1448,9 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.37.103",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.103.tgz",
-			"integrity": "sha512-r+qitxXKe2l6KFw5odPdZSSqdEou+7eNC7BfbZ7mny5Me/K06wCTeKUMVeH/YsI9+4QQudskeQ307kr/7ppQ1A=="
+			"version": "0.37.109",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.109.tgz",
+			"integrity": "sha512-B4W/ao8vempNVCS4/K4CeeCGhiabTcU7ekgqJy4/RytEsgkJP9hWS0MWZMcRP3wWzU/FXi6QqqvArZTJUfc6Iw=="
 		},
 		"node_modules/discord.js": {
 			"version": "14.17.0-dev.1728000701-c1b849fa5",
@@ -1659,7 +1676,6 @@
 			"version": "8.8.3",
 			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.8.3.tgz",
 			"integrity": "sha512-/I4n/DcXqXyIiLRfAmUIiTjj3vXfeISke8dt4U4Y8Wfm074Wa6sXnQrXN49NFOFf2mM1kUdOXryoBvkuCnr+Qw==",
-			"license": "MIT",
 			"dependencies": {
 				"bson": "^6.7.0",
 				"kareem": "2.6.3",
@@ -1907,9 +1923,9 @@
 			"integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
 		},
 		"node_modules/tslib": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-			"integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
 		},
 		"node_modules/type-fest": {
 			"version": "2.19.0",


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@discordjs/formatters@0.6.0-dev.1730030720-ed78e4570`](https://npmjs.com/package/@discordjs/formatters/v/0.6.0-dev.1730030720-ed78e4570) to [`1.0.0-dev.1732795526-2b0944a92`](https://npmjs.com/package/@discordjs/formatters/v/1.0.0-dev.1732795526-2b0944a92) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.4.1-dev.1730030709-ed78e4570`](https://npmjs.com/package/@discordjs/rest/v/2.4.1-dev.1730030709-ed78e4570) to [`3.0.0-dev.1732795513-2b0944a92`](https://npmjs.com/package/@discordjs/rest/v/3.0.0-dev.1732795513-2b0944a92) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Installed [`@sapphire/snowflake@3.5.5`](https://npmjs.com/package/@sapphire/snowflake/v/3.5.5)
- Installed [`undici@6.21.0`](https://npmjs.com/package/undici/v/6.21.0)
- Bumped [`@discordjs/util@1.1.2-dev.1730030707-ed78e4570`](https://npmjs.com/package/@discordjs/util/v/1.1.2-dev.1730030707-ed78e4570) to [`2.0.0-dev.1732795513-2b0944a92`](https://npmjs.com/package/@discordjs/util/v/2.0.0-dev.1732795513-2b0944a92) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
- Bumped [`@sapphire/async-queue@1.5.3`](https://npmjs.com/package/@sapphire/async-queue/v/1.5.3) to [`1.5.5`](https://npmjs.com/package/@sapphire/async-queue/v/1.5.5) ([see recent commits](https://github.com/sapphiredev/utilities/commits/HEAD/packages/async-queue))
- Bumped [`@types/ws@8.5.12`](https://npmjs.com/package/@types/ws/v/8.5.12) to [`8.5.13`](https://npmjs.com/package/@types/ws/v/8.5.13) ([see recent commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/ws))
- Bumped [`bson@6.9.0`](https://npmjs.com/package/bson/v/6.9.0) to [`6.10.0`](https://npmjs.com/package/bson/v/6.10.0) ([see recent commits](https://github.com/mongodb/js-bson))
- Bumped [`discord-api-types@0.37.103`](https://npmjs.com/package/discord-api-types/v/0.37.103) to [`0.37.109`](https://npmjs.com/package/discord-api-types/v/0.37.109) ([see recent commits](https://github.com/discordjs/discord-api-types))
- Bumped [`tslib@2.8.0`](https://npmjs.com/package/tslib/v/2.8.0) to [`2.8.1`](https://npmjs.com/package/tslib/v/2.8.1) ([see recent commits](https://github.com/Microsoft/tslib))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
